### PR TITLE
fix: replace timeout by link and customize chunks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-router-dom": "^6.26.1"
       },
       "devDependencies": {
         "@types/react": "^18.0.26",
@@ -772,6 +773,14 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "node_modules/@remix-run/router": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.19.1.tgz",
+      "integrity": "sha512-S45oynt/WH19bHbIXjtli6QmwNYvaz+vtnubvNpNDvUOoA/OWh6j1OikIP3G+v5GHdxyC6EXoChG3HgYGEUfcg==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
@@ -1220,6 +1229,36 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.26.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.26.1.tgz",
+      "integrity": "sha512-kIwJveZNwp7teQRI5QmwWo39A5bXRyqpH0COKKmPnyD2vBvDwgFXSqDUYtt1h+FEyfnE8eXr7oe0MxRzVwCcvQ==",
+      "dependencies": {
+        "@remix-run/router": "1.19.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.26.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.26.1.tgz",
+      "integrity": "sha512-veut7m41S1fLql4pLhxeSW3jlqs+4MtjRLj0xvuCEXsxusJCbs6I8yn9BxzzDX2XDgafrccY6hwjmd/bL54tFw==",
+      "dependencies": {
+        "@remix-run/router": "1.19.1",
+        "react-router": "6.26.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/resolve": {
@@ -1852,6 +1891,11 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "@remix-run/router": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.19.1.tgz",
+      "integrity": "sha512-S45oynt/WH19bHbIXjtli6QmwNYvaz+vtnubvNpNDvUOoA/OWh6j1OikIP3G+v5GHdxyC6EXoChG3HgYGEUfcg=="
+    },
     "@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
@@ -2174,6 +2218,23 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
       "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
       "dev": true
+    },
+    "react-router": {
+      "version": "6.26.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.26.1.tgz",
+      "integrity": "sha512-kIwJveZNwp7teQRI5QmwWo39A5bXRyqpH0COKKmPnyD2vBvDwgFXSqDUYtt1h+FEyfnE8eXr7oe0MxRzVwCcvQ==",
+      "requires": {
+        "@remix-run/router": "1.19.1"
+      }
+    },
+    "react-router-dom": {
+      "version": "6.26.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.26.1.tgz",
+      "integrity": "sha512-veut7m41S1fLql4pLhxeSW3jlqs+4MtjRLj0xvuCEXsxusJCbs6I8yn9BxzzDX2XDgafrccY6hwjmd/bL54tFw==",
+      "requires": {
+        "@remix-run/router": "1.19.1",
+        "react-router": "6.26.1"
+      }
     },
     "resolve": {
       "version": "1.22.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.26.1"
   },
   "devDependencies": {
     "@types/react": "^18.0.26",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,36 +1,38 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import reactLogo from "./assets/react.svg";
+import { BrowserRouter, Routes, Route, Link } from "react-router-dom";
 import "./App.css";
 const Foo = React.lazy(() => import("./Foo"));
 
 function App() {
-  const [count, setCount] = useState(0);
-  const [showFoo, setShowFoo] = useState(false);
-
-  useEffect(() => {
-    setTimeout(() => setShowFoo(true), 30000);
-  });
-
   return (
-    <div className="App">
-      <div>
-        <a href="https://vitejs.dev" target="_blank">
-          <img src="/vite.svg" className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://reactjs.org" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        {showFoo ? <Foo /> : null}
-        <button onClick={() => setCount((count) => count + 1)}>count is {count}</button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
+    <BrowserRouter>
+      <div className="App">
+        <div>
+          <a href="https://vitejs.dev" target="_blank">
+            <img src="/vite.svg" className="logo" alt="Vite logo" />
+          </a>
+          <a href="https://reactjs.org" target="_blank">
+            <img src={reactLogo} className="logo react" alt="React logo" />
+          </a>
+        </div>
+        <h1>Vite + React</h1>
+        <div className="card">
+          <Link to="/foo">
+            <button>Go to Foo</button>
+          </Link>
+          <p>
+            Edit <code>src/App.jsx</code> and save to test HMR
+          </p>
+        </div>
+        <p className="read-the-docs">
+          Click on the Vite and React logos to learn more
         </p>
+        <Routes>
+          <Route path="/foo" element={<Foo />} />
+        </Routes>
       </div>
-      <p className="read-the-docs">Click on the Vite and React logos to learn more</p>
-    </div>
+    </BrowserRouter>
   );
 }
 

--- a/src/Foo.jsx
+++ b/src/Foo.jsx
@@ -1,3 +1,3 @@
-const Foo = () => <p>Foo2</p>;
+const Foo = () => <p>Foo V1</p>;
 
 export default Foo;

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,33 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import path from 'node:path'
+
+
+const deriveFileNameFromChunkInfo = (chunkInfo) => {
+  if (!chunkInfo.facadeModuleId) {
+    return 'assets/js/[name]-[hash].js';
+  }
+
+  const basename = path.basename(chunkInfo.facadeModuleId);
+  if (basename.startsWith('@')) {
+    return 'assets/js/[name]-[hash].js';
+  }
+
+  const ext = path.extname(chunkInfo.facadeModuleId);
+  const outputFileName = chunkInfo.facadeModuleId.replace(__dirname, 'assets/js').replace(ext, '.js');
+  return outputFileName;
+};
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  build: {
+    rollupOptions: {
+      output: {
+        chunkFileNames: deriveFileNameFromChunkInfo,
+        entryFileNames: deriveFileNameFromChunkInfo,
+        assetFileNames: 'assets/[ext]/[name].[ext]',
+      },
+    },
+  },
 })


### PR DESCRIPTION
# What and why was modified?

- Chunk file name and path outputs were customized using [rollulpOptions](https://rollupjs.org/configuration-options/#output-chunkfilenames) to prevent errors when files are updated;
- Replaced delay by link to try to reproduce and fix the issue https://github.com/vitejs/vite/issues/11804 for the following use case:
  - WHEN user loads initial page before a new deployment is made;
  - AND a new deployment removes a dynamically imported module that was referenced in the previous deployment;
  - AND user clicks a link that is available in his stale version;
  - THEN user experiences an error `TypeError: Failed to fetch dynamically imported module`;

